### PR TITLE
Fix for subscriber authentication

### DIFF
--- a/subscriber.js
+++ b/subscriber.js
@@ -23,7 +23,7 @@ const Subscriber = function(url, port, auth, topics) {
         };
 
         if (auth) {
-            options.user = auth.user;
+            options.username = auth.user;
             options.password = auth.password;
         }
 


### PR DESCRIPTION
This fixes a problem with using username/password to connect to a MQTT broker. Per the mqtt.js documentation, the parameters are username/password. The `subscriber.js` file sets the authentication to `user` and `password`. This mismatch prevents authentication.

This PR corrects the missmatch and allows username & password authentication to proceed.

Documentation reference here: [MQTT.js documentation](https://github.com/mqttjs/MQTT.js/?tab=readme-ov-file#client)

